### PR TITLE
fix platform version parsing on android

### DIFF
--- a/utils/platform.ts
+++ b/utils/platform.ts
@@ -10,7 +10,11 @@ export const isAndroid = () => {
 
 export const getPlatformVersion = () => {
   const version = Platform.Version;
-  const major = parseInt(version.toString().split(".")[0], 10);
-  const minor = parseInt(version.toString().split(".")[1], 10);
-  return major * 10 + minor;
+  if (typeof version === "string") {
+    const [majorStr, minorStr = "0"] = version.split(".");
+    const major = parseInt(majorStr, 10);
+    const minor = parseInt(minorStr, 10);
+    return major * 10 + minor;
+  }
+  return version;
 };


### PR DESCRIPTION
## Summary
- handle numeric Platform.Version values in getPlatformVersion

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab524c81ec83328a1302233830e840