### PR TITLE
fix: resolve expo gradle plugin for android builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -77,7 +77,8 @@
             "LocationWhenInUse"
           ]
         }
-      ]
+      ],
+      "./plugins/withExpoModuleGradlePlugin"
     ],
     "experiments": {
       "typedRoutes": true

--- a/plugins/withExpoModuleGradlePlugin.js
+++ b/plugins/withExpoModuleGradlePlugin.js
@@ -1,0 +1,25 @@
+const { withSettingsGradle } = require('@expo/config-plugins');
+
+module.exports = function withExpoModuleGradlePlugin(config) {
+  return withSettingsGradle(config, config => {
+    const contents = config.modResults.contents;
+    if (!contents.includes('expo-module-gradle-plugin')) {
+      config.modResults.contents = `pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "expo-module-gradle-plugin") {
+                useModule("expo.modules:expo-module-gradle-plugin:+")
+            }
+        }
+    }
+}
+` + contents;
+    }
+    return config;
+  });
+};


### PR DESCRIPTION
## Summary
- add config plugin to inject gradle resolution for expo modules
- register the custom plugin in app config

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_b_68ab622f55b08332a6fc28a809b269d8